### PR TITLE
Fix: Allow publishers to submit service reports

### DIFF
--- a/serviceFormscript.js
+++ b/serviceFormscript.js
@@ -33,9 +33,11 @@ if (!serviceForm) {
       if (noticeEl) noticeEl.style.display = 'block';
       if (roleSelect.value === 'publisher') {
         hoursInput.disabled = true;
+        hoursInput.required = false;
         hoursInput.value = '';
       } else {
         hoursInput.disabled = false;
+        hoursInput.required = true;
       }
     });
   }


### PR DESCRIPTION
The service report form was preventing users with the 'Publicador' (Publisher) role from submitting their reports.

This was caused by the 'hours' input field retaining the 'required' attribute even when it was disabled for this role. The form's validity check would fail because the disabled, required field had no value.

This commit modifies `serviceFormscript.js` to dynamically remove the 'required' attribute from the 'hours' input when the 'Publicador' role is selected and adds it back for other roles. This ensures that the form validation works correctly for all user roles.